### PR TITLE
Complete translation support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,6 +7,8 @@ const PopupMenu = imports.ui.popupMenu;
 const Convenience = imports.misc.extensionUtils;
 const Me = Convenience.getCurrentExtension();
 // const Util = imports.misc.util;
+const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
+const _ = Gettext.gettext;
 
 const Lang = imports.lang;
 
@@ -72,7 +74,7 @@ var HassExtension = GObject.registerClass ({
         for (let entity of togglables) {
             if (entity.entity_id === "" || !entity.entity_id.includes("."))
                 continue
-            let pmItem = new PopupMenu.PopupMenuItem('Toggle:');
+            let pmItem = new PopupMenu.PopupMenuItem(_('Toggle:'));
             pmItem.add_child(
                 new St.Label({
                     text : entity.name
@@ -90,11 +92,11 @@ var HassExtension = GObject.registerClass ({
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         // Now build the submenu containing the HASS events
-        let subItem = new PopupMenu.PopupSubMenuMenuItem('HASS Events');
+        let subItem = new PopupMenu.PopupSubMenuMenuItem(_('HASS Events'));
         this.menu.addMenuItem(subItem);
-        let start_hass_item = new PopupMenu.PopupMenuItem('Start Home Assistant');
-        let stop_hass_item = new PopupMenu.PopupMenuItem('Stop Home Assistant');
-        let close_hass_item = new PopupMenu.PopupMenuItem('Close Home Assistant');
+        let start_hass_item = new PopupMenu.PopupMenuItem(_('Start Home Assistant'));
+        let stop_hass_item = new PopupMenu.PopupMenuItem(_('Stop Home Assistant'));
+        let close_hass_item = new PopupMenu.PopupMenuItem(_('Close Home Assistant'));
         subItem.menu.addMenuItem(start_hass_item, 0);
         subItem.menu.addMenuItem(stop_hass_item, 1);
         subItem.menu.addMenuItem(close_hass_item, 2);
@@ -110,7 +112,7 @@ var HassExtension = GObject.registerClass ({
 
         // Settings button (Preferences)
         let popupImageMenuItem = new PopupMenu.PopupImageMenuItem(
-            "Preferences",
+            _("Preferences"),
             'security-high-symbolic',
         );
         popupImageMenuItem.connect('activate', () => {
@@ -427,7 +429,7 @@ var HassExtension = GObject.registerClass ({
 
 
 function init() {
-
+  Convenience.initTranslations();
 }
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,7 @@
     ],
     "url" : "https://github.com/geoph9/hass-gshell-extension",
     "settings-schema": "org.gnome.shell.extensions.hass-data",
+    "gettext-domain": "hass-gshell",
     "uuid" : "hass-gshell@geoph9-on-github",
     "version" : "1.5.2"
 }

--- a/po/hass-gshell.pot
+++ b/po/hass-gshell.pot
@@ -1,0 +1,269 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-05-07 17:25+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:16
+msgid "Panel Icon."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:17
+msgid "The default icon that will be visible in the panel."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:22
+msgid "Complete list of valid panel icons for the extension."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:23
+msgid ""
+"The paths have to be relative to the directory where the 'extension.js' file "
+"is located."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:28
+msgid "Refresh Rate"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:29
+msgid ""
+"(Currently Broken) The refresh rate for the weather statistics in seconds "
+"(works only if \"Refresh Temperature/Humidity Sensors\" is enabled)."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:34
+msgid "Refresh Temperature/Humidity Sensors"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:35
+msgid ""
+"(Currently Broken) Whether or not you want to refresh the temperature and/or "
+"humidity sensor values."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:40
+msgid "Show notifications"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:41
+msgid "Show notifications when enabled/disabled."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:46
+msgid "Show Temperature/Humidity"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:47
+msgid ""
+"Whether to show the temperature and/or humidity values (assuming you have "
+"provided the corresponding entity ids)."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:52
+msgid "Show Humidity"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:53
+msgid "Whether to show humidity value or not."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:58
+msgid "Temperature ID"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:59
+msgid "Your Home Assistant EntityID for the temperature sensor."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:64
+msgid "Humidity ID"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:65
+msgid "Your Home Assistant EntityID for the humidity sensor."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:70
+msgid "Access Token"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:71
+msgid ""
+"Long Live Access Token for Home Assistant (Go to Profile->Bottom-of-the-page-"
+">Long-Live-Access-Tokens and create a new one)."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:76
+msgid "URL"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:77
+msgid "The url where your hass instance is hosted."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:82
+msgid "Complete list of entity ids for home-assistant switches."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:83
+msgid ""
+"Full list of home assistant switches. It is meant to be filled automatically "
+"after pressing the 'Scan' button in the Preferences menu."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:88
+msgid "Entity ids for home-assistant switches."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:89
+msgid ""
+"Entity ids for home-assistant switches. E.g. switch.livingroom_lights_relay."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:94 prefs.js:56
+msgid "Panel Sensors"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:95
+msgid ""
+"List of entity ids for the sensor values that you want to show in the panel ."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:100
+msgid "Entity ids for home assistant sensors."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:101
+msgid ""
+"Entity ids for home-assistant sensors. E.g. sensor.livingroom_temperature ."
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:112
+msgid "Home Assistant Extension - Shortcut Key"
+msgstr ""
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:113
+msgid "Shortcut key on how to open the extension's menu from the tray."
+msgstr ""
+
+#: extension.js:77
+msgid "Toggle:"
+msgstr ""
+
+#: extension.js:95
+msgid "HASS Events"
+msgstr ""
+
+#: extension.js:97
+msgid "Start Home Assistant"
+msgstr ""
+
+#: extension.js:98
+msgid "Stop Home Assistant"
+msgstr ""
+
+#: extension.js:99
+msgid "Close Home Assistant"
+msgstr ""
+
+#: extension.js:115
+msgid "Preferences"
+msgstr ""
+
+#: prefs.js:48
+msgid "General Settings"
+msgstr ""
+
+#: prefs.js:51
+msgid "Togglables"
+msgstr ""
+
+#: prefs.js:82
+msgid "Global options:"
+msgstr ""
+
+#: prefs.js:100
+msgid "Temperature/Humidity options:"
+msgstr ""
+
+#: prefs.js:129
+msgid "Panel Icon Options:"
+msgstr ""
+
+#: prefs.js:146
+msgid " Icon"
+msgstr ""
+
+#: prefs.js:154
+msgid ""
+"You will need to restart your session in order for this change to take "
+"effect."
+msgstr ""
+
+#: prefs.js:155
+msgid ""
+"On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this "
+"doesn't work (Wayland), you have to logout and re-login."
+msgstr ""
+
+#: prefs.js:279
+msgid "Togglable Entities:"
+msgstr ""
+
+#: prefs.js:284
+msgid "Choose Togglable Entities:"
+msgstr ""
+
+#: prefs.js:307
+msgid "Group Switches"
+msgstr ""
+
+#: prefs.js:314
+msgid "Experimental"
+msgstr ""
+
+#: prefs.js:315
+msgid "Does not currently work."
+msgstr ""
+
+#: prefs.js:406
+msgid "Sensors:"
+msgstr ""
+
+#: prefs.js:411
+msgid "Choose Which Sensors Should Appear on the Panel:"
+msgstr ""
+
+#: prefs.js:583
+msgid "Do you want to have the '"
+msgstr ""
+
+#: prefs.js:583
+msgid "' icon in your panel?"
+msgstr ""
+
+#: prefs.js:585
+msgid "Do you want to show "
+msgstr ""
+
+#: prefs.js:585
+msgid " in the tray menu?"
+msgstr ""
+
+#: prefs.js:632
+msgid "Add"
+msgstr ""

--- a/prefs.js
+++ b/prefs.js
@@ -5,7 +5,8 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 const Settings = Me.imports.settings;
-const _  = Settings._;
+const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
+const _ = Gettext.gettext;
 
 // const Convenience = Me.imports.utils;
 const Convenience = imports.misc.extensionUtils;
@@ -31,6 +32,7 @@ let _settings = Convenience.getSettings(HASS_SETTINGS);
 
 function init() {
     schema = _settings.settings_schema;
+    Convenience.initTranslations();
     log(`initializing ${Me.metadata.name} Preferences`);
 }
 
@@ -141,7 +143,7 @@ function _buildGeneralSettings() {
                       .split("-")
                       .map(word => word.charAt(0).toUpperCase() + word.slice(1))
                       .join(" ");
-        let [iconItem, panelIconCheckBox] = _makeCheckBox(label + " Icon", checked, superGroup);
+        let [iconItem, panelIconCheckBox] = _makeCheckBox(label + _(" Icon"), checked, superGroup);
         optionsList.push(iconItem);
         iconCheckBoxes.push({
             icon: ic,
@@ -149,8 +151,8 @@ function _buildGeneralSettings() {
         });
     }
     optionsList.push(_optionsItem(
-        "You will need to restart your session in order for this change to take effect.",
-        "On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this doesn't work (Wayland), you have to logout and re-login.",
+        _("You will need to restart your session in order for this change to take effect."),
+        _("On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this doesn't work (Wayland), you have to logout and re-login."),
         new Gtk.Label(),
         null
     ));
@@ -309,8 +311,8 @@ function _buildTogglableSettings() {
         )
     );
     optionsList.push(_optionsItem(
-        "Experimental",
-        "Does not currently work.",
+        _("Experimental"),
+        _("Does not currently work."),
         new Gtk.Label(),
         null
     ));
@@ -627,7 +629,7 @@ function _newGtkEntryButton() {
     let addButton = new Gtk.Button({
         halign: Gtk.Align.END,
         valign: Gtk.Align.CENTER, 
-        label: "Add",
+        label: _("Add"),
         hexpand: true
     });
     return [textEntry, addButton]

--- a/settings.js
+++ b/settings.js
@@ -4,11 +4,6 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 
-
-const Gettext = imports.gettext.domain(Me.metadata['gettext-domain']);
-// var _ = Gettext.gettext;
-var _ = (t) => t;
-
 const PANEL_ICON_PATH = "default-panel-icon";
 const VALID_PANEL_ICONS = 'valid-panel-icons';
 const HASS_ACCESS_TOKEN = 'hass-access-token';


### PR DESCRIPTION
.pot file generated with:
`xgettext --from-code=UTF-8 schemas/org.gnome.shell.extensions.hass-data.gschema.xml extension.js prefs.js --output=po/hass-gshell.pot`

Also used `gnome-extensions` command which takes care of the process for the extension directory structure:
`gnome-extensions pack -f --extra-source=icons --extra-source=settings.js --extra-source=utils.js -o .`
`gnome-extensions install -f hass-gshell@geoph9-on-github.shell-extension.zip`