### PR TITLE
Add french translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-26 21:49+0100\n"
-"PO-Revision-Date: 2023-01-26 22:13+0100\n"
+"POT-Creation-Date: 2023-06-25 09:46+0200\n"
+"PO-Revision-Date: 2023-06-25 09:52+0200\n"
 "Last-Translator: Roy Meissner\n"
 "Language-Team: \n"
 "Language: de_DE\n"
@@ -16,7 +16,117 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: extension.js:75
+msgid "Toggle:"
+msgstr "Umschalten:"
+
+#: extension.js:93
+msgid "HASS Events"
+msgstr "Home Assistant Ereignisse"
+
+#: extension.js:95
+msgid "Start Home Assistant"
+msgstr "Starte Home Assistant"
+
+#: extension.js:96
+msgid "Stop Home Assistant"
+msgstr "Stoppe Home Assistant"
+
+#: extension.js:97
+msgid "Close Home Assistant"
+msgstr "Home Assistant schließen"
+
+#: extension.js:113
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: prefs.js:48
+msgid "General Settings"
+msgstr "Allgemeine Einstellungen"
+
+#: prefs.js:51
+msgid "Togglables"
+msgstr "Schaltbares"
+
+#: prefs.js:56 schemas/org.gnome.shell.extensions.hass-data.gschema.xml:94
+msgid "Panel Sensors"
+msgstr "Panel-Sensoren"
+
+#: prefs.js:85
+msgid "Global options:"
+msgstr "Globale Optionen:"
+
+#: prefs.js:103
+msgid "Temperature/Humidity options:"
+msgstr "Optionen für Temperatur/Luftfeuchtigkeit:"
+
+#: prefs.js:132
+msgid "Panel Icon Options:"
+msgstr "Panel Icon Optionen:"
+
+#: prefs.js:149
+#, javascript-format
+msgid "%s Icon"
+msgstr "%s Icon"
+
+#: prefs.js:157
+msgid ""
+"You will need to restart your session in order for this change to take "
+"effect."
+msgstr ""
+"Sie müssen sich abmelden und neu anmelden, damit diese Änderung wirksam wird."
+
+#: prefs.js:158
+msgid ""
+"On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this "
+"doesn't work (Wayland), you have to logout and re-login."
+msgstr ""
+"Bei Xorg können Sie das mit Alt+F2 und dann mit 'r' und Enter machen. Wenn "
+"das nicht funktioniert (Wayland), müssen Sie sich abmelden und neu anmelden."
+
+#: prefs.js:282
+msgid "Togglable Entities:"
+msgstr "Umschaltbare Entitäten:"
+
+#: prefs.js:287
+msgid "Choose Togglable Entities:"
+msgstr "Wählen Sie umschaltbare Entitäten:"
+
+#: prefs.js:310
+msgid "Group Switches"
+msgstr "Gruppen-Schalter"
+
+#: prefs.js:317
+msgid "Experimental"
+msgstr "Experimentell"
+
+#: prefs.js:318
+msgid "Does not currently work."
+msgstr "Funktioniert aktuell nicht."
+
+#: prefs.js:409
+msgid "Sensors:"
+msgstr "Sensoren:"
+
+#: prefs.js:414
+msgid "Choose Which Sensors Should Appear on the Panel:"
+msgstr "Wählen Sie aus, welche Sensoren im Panel angezeigt werden sollen:"
+
+#: prefs.js:586
+#, javascript-format
+msgid "Do you want to have the '%s' icon in your panel?"
+msgstr "Möchten Sie das '%s' Icon in Ihrem Panel?"
+
+#: prefs.js:588
+#, javascript-format
+msgid "Do you want to show %s in the tray menu?"
+msgstr "Möchten Sie anzeigen %s im Panel?"
+
+#: prefs.js:635
+msgid "Add"
+msgstr "Hinzufügen"
 
 #: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:16
 msgid "Panel Icon."
@@ -150,10 +260,6 @@ msgid ""
 msgstr ""
 "Entity-IDs für Home-Assistant-Schalter. z.B. switch.livingroom_lights_relay."
 
-#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:94 prefs.js:56
-msgid "Panel Sensors"
-msgstr "Panel-Sensoren"
-
 #: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:95
 msgid ""
 "List of entity ids for the sensor values that you want to show in the panel ."
@@ -179,113 +285,8 @@ msgstr "Home Assistant Erweiterung - Tastenkombination"
 msgid "Shortcut key on how to open the extension's menu from the tray."
 msgstr "Tastenkombination zum Öffnen des Menüs der Erweiterung über das Panel."
 
-#: extension.js:77
-msgid "Toggle:"
-msgstr "Umschalten:"
+#~ msgid "' icon in your panel?"
+#~ msgstr "' Icon in Ihrem Panel?"
 
-#: extension.js:95
-msgid "HASS Events"
-msgstr "Home Assistant Ereignisse"
-
-#: extension.js:97
-msgid "Start Home Assistant"
-msgstr "Starte Home Assistant"
-
-#: extension.js:98
-msgid "Stop Home Assistant"
-msgstr "Stoppe Home Assistant"
-
-#: extension.js:99
-msgid "Close Home Assistant"
-msgstr "Home Assistant schließen"
-
-#: extension.js:115
-msgid "Preferences"
-msgstr "Einstellungen"
-
-#: prefs.js:48
-msgid "General Settings"
-msgstr "Allgemeine Einstellungen"
-
-#: prefs.js:51
-msgid "Togglables"
-msgstr "Schaltbares"
-
-#: prefs.js:82
-msgid "Global options:"
-msgstr "Globale Optionen:"
-
-#: prefs.js:100
-msgid "Temperature/Humidity options:"
-msgstr "Optionen für Temperatur/Luftfeuchtigkeit:"
-
-#: prefs.js:129
-msgid "Panel Icon Options:"
-msgstr "Panel Icon Optionen:"
-
-#: prefs.js:146
-msgid " Icon"
-msgstr " Icon"
-
-#: prefs.js:154
-msgid ""
-"You will need to restart your session in order for this change to take "
-"effect."
-msgstr ""
-"Sie müssen sich abmelden und neu anmelden, damit diese Änderung wirksam wird."
-
-#: prefs.js:155
-msgid ""
-"On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this "
-"doesn't work (Wayland), you have to logout and re-login."
-msgstr ""
-"Bei Xorg können Sie das mit Alt+F2 und dann mit 'r' und Enter machen. Wenn "
-"das nicht funktioniert (Wayland), müssen Sie sich abmelden und neu anmelden."
-
-#: prefs.js:279
-msgid "Togglable Entities:"
-msgstr "Umschaltbare Entitäten:"
-
-#: prefs.js:284
-msgid "Choose Togglable Entities:"
-msgstr "Wählen Sie umschaltbare Entitäten:"
-
-#: prefs.js:307
-msgid "Group Switches"
-msgstr "Gruppen-Schalter"
-
-#: prefs.js:314
-msgid "Experimental"
-msgstr "Experimentell"
-
-#: prefs.js:315
-msgid "Does not currently work."
-msgstr "Funktioniert aktuell nicht."
-
-#: prefs.js:406
-msgid "Sensors:"
-msgstr "Sensoren:"
-
-#: prefs.js:411
-msgid "Choose Which Sensors Should Appear on the Panel:"
-msgstr "Wählen Sie aus, welche Sensoren im Panel angezeigt werden sollen:"
-
-#: prefs.js:583
-msgid "Do you want to have the '"
-msgstr "Möchten Sie das '"
-
-#: prefs.js:583
-msgid "' icon in your panel?"
-msgstr "' Icon in Ihrem Panel?"
-
-#: prefs.js:585
-msgid "Do you want to show "
-msgstr "Möchten Sie anzeigen "
-
-#: prefs.js:585
-msgid " in the tray menu?"
-msgstr " im Panel?"
-
-#: prefs.js:632
-msgid "Add"
-msgstr "Hinzufügen"
+#~ msgid " in the tray menu?"
+#~ msgstr " im Panel?"

--- a/po/es.po
+++ b/po/es.po
@@ -7,16 +7,125 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-07 17:25+0200\n"
-"PO-Revision-Date: 2022-05-07 17:25+0200\n"
-"Last-Translator: \n"
+"POT-Creation-Date: 2023-06-25 09:46+0200\n"
+"PO-Revision-Date: 2023-06-25 09:51+0200\n"
+"Last-Translator: Benjamin Renard\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: extension.js:75
+msgid "Toggle:"
+msgstr "Conmutar:"
+
+#: extension.js:93
+msgid "HASS Events"
+msgstr "Eventos de HASS"
+
+#: extension.js:95
+msgid "Start Home Assistant"
+msgstr "Iniciar Home Assistant"
+
+#: extension.js:96
+msgid "Stop Home Assistant"
+msgstr "Detener Home Assistant"
+
+#: extension.js:97
+msgid "Close Home Assistant"
+msgstr "Cerrar Home Assistant"
+
+#: extension.js:113
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: prefs.js:48
+msgid "General Settings"
+msgstr "Ajustes generales"
+
+#: prefs.js:51
+msgid "Togglables"
+msgstr "Conmutables"
+
+#: prefs.js:56 schemas/org.gnome.shell.extensions.hass-data.gschema.xml:94
+msgid "Panel Sensors"
+msgstr "Sensores del panel"
+
+#: prefs.js:85
+msgid "Global options:"
+msgstr "Opciones globales:"
+
+#: prefs.js:103
+msgid "Temperature/Humidity options:"
+msgstr "Opciones de temperatura/humedad:"
+
+#: prefs.js:132
+msgid "Panel Icon Options:"
+msgstr "Opciones de iconos del panel:"
+
+#: prefs.js:149
+#, javascript-format
+msgid "%s Icon"
+msgstr "Icono %s"
+
+#: prefs.js:157
+msgid ""
+"You will need to restart your session in order for this change to take "
+"effect."
+msgstr "Deberá reiniciar su sesión para que este cambio surta efecto."
+
+#: prefs.js:158
+msgid ""
+"On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this "
+"doesn't work (Wayland), you have to logout and re-login."
+msgstr ""
+"En Xorg, puede hacerlo con Alt+F2 y luego pulsando 'r' y Enter. Si esto no "
+"funciona (Wayland), debe cerrar la sesión y volver a iniciarla."
+
+#: prefs.js:282
+msgid "Togglable Entities:"
+msgstr "Entidades conmutables:"
+
+#: prefs.js:287
+msgid "Choose Togglable Entities:"
+msgstr "Seleccionar entidades conmutables:"
+
+#: prefs.js:310
+msgid "Group Switches"
+msgstr "Interruptores de grupo"
+
+#: prefs.js:317
+msgid "Experimental"
+msgstr "Experimental"
+
+#: prefs.js:318
+msgid "Does not currently work."
+msgstr "No funciona actualmente."
+
+#: prefs.js:409
+msgid "Sensors:"
+msgstr "Sensores:"
+
+#: prefs.js:414
+msgid "Choose Which Sensors Should Appear on the Panel:"
+msgstr "Seleccione los sensores que deben aparecer en el panel:"
+
+#: prefs.js:586
+#, javascript-format
+msgid "Do you want to have the '%s' icon in your panel?"
+msgstr "¿Quiere tener el '%s' icono en su panel?"
+
+#: prefs.js:588
+#, javascript-format
+msgid "Do you want to show %s in the tray menu?"
+msgstr "¿Quiere mostrar %s en la bandeja del menú?"
+
+#: prefs.js:635
+msgid "Add"
+msgstr "Añadir"
 
 #: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:16
 msgid "Panel Icon."
@@ -153,10 +262,6 @@ msgstr ""
 "Identificadores de entidad para los interruptores de asistencia al hogar. "
 "Por ejemplo, switch.livingroom_lights_relay."
 
-#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:94 prefs.js:56
-msgid "Panel Sensors"
-msgstr "Sensores del panel"
-
 #: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:95
 msgid ""
 "List of entity ids for the sensor values that you want to show in the panel ."
@@ -183,112 +288,8 @@ msgstr "Home Assistant Extension - Atajo del teclado"
 msgid "Shortcut key on how to open the extension's menu from the tray."
 msgstr "Atajo para abrir el menú de la extensión desde la bandeja."
 
-#: extension.js:77
-msgid "Toggle:"
-msgstr "Conmutar:"
+#~ msgid "' icon in your panel?"
+#~ msgstr "' icono en su panel?"
 
-#: extension.js:95
-msgid "HASS Events"
-msgstr "Eventos de HASS"
-
-#: extension.js:97
-msgid "Start Home Assistant"
-msgstr "Iniciar Home Assistant"
-
-#: extension.js:98
-msgid "Stop Home Assistant"
-msgstr "Detener Home Assistant"
-
-#: extension.js:99
-msgid "Close Home Assistant"
-msgstr "Cerrar Home Assistant"
-
-#: extension.js:115
-msgid "Preferences"
-msgstr "Preferencias"
-
-#: prefs.js:48
-msgid "General Settings"
-msgstr "Ajustes generales"
-
-#: prefs.js:51
-msgid "Togglables"
-msgstr "Conmutables"
-
-#: prefs.js:82
-msgid "Global options:"
-msgstr "Opciones globales:"
-
-#: prefs.js:100
-msgid "Temperature/Humidity options:"
-msgstr "Opciones de temperatura/humedad:"
-
-#: prefs.js:129
-msgid "Panel Icon Options:"
-msgstr "Opciones de iconos del panel:"
-
-#: prefs.js:146
-msgid " Icon"
-msgstr " Icono"
-
-#: prefs.js:154
-msgid ""
-"You will need to restart your session in order for this change to take "
-"effect."
-msgstr "Deberá reiniciar su sesión para que este cambio surta efecto."
-
-#: prefs.js:155
-msgid ""
-"On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this "
-"doesn't work (Wayland), you have to logout and re-login."
-msgstr ""
-"En Xorg, puede hacerlo con Alt+F2 y luego pulsando 'r' y Enter. Si esto no "
-"funciona (Wayland), debe cerrar la sesión y volver a iniciarla."
-
-#: prefs.js:279
-msgid "Togglable Entities:"
-msgstr "Entidades conmutables:"
-
-#: prefs.js:284
-msgid "Choose Togglable Entities:"
-msgstr "Seleccionar entidades conmutables:"
-
-#: prefs.js:307
-msgid "Group Switches"
-msgstr "Interruptores de grupo"
-
-#: prefs.js:314
-msgid "Experimental"
-msgstr "Experimental"
-
-#: prefs.js:315
-msgid "Does not currently work."
-msgstr "No funciona actualmente."
-
-#: prefs.js:406
-msgid "Sensors:"
-msgstr "Sensores:"
-
-#: prefs.js:411
-msgid "Choose Which Sensors Should Appear on the Panel:"
-msgstr "Seleccione los sensores que deben aparecer en el panel:"
-
-#: prefs.js:583
-msgid "Do you want to have the '"
-msgstr "¿Quiere tener el '"
-
-#: prefs.js:583
-msgid "' icon in your panel?"
-msgstr "' icono en su panel?"
-
-#: prefs.js:585
-msgid "Do you want to show "
-msgstr "¿Quiere mostrar "
-
-#: prefs.js:585
-msgid " in the tray menu?"
-msgstr " en la bandeja del menú?"
-
-#: prefs.js:632
-msgid "Add"
-msgstr "Añadir"
+#~ msgid " in the tray menu?"
+#~ msgstr " en la bandeja del menú?"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,0 +1,303 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-06-25 09:46+0200\n"
+"PO-Revision-Date: 2023-06-25 10:00+0200\n"
+"Last-Translator: Benjamin Renard\n"
+"Language-Team: \n"
+"Language: fr_FR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: extension.js:75
+msgid "Toggle:"
+msgstr "Allumer/Éteindre :"
+
+#: extension.js:93
+msgid "HASS Events"
+msgstr "Évènements HASS"
+
+#: extension.js:95
+msgid "Start Home Assistant"
+msgstr "Démarrer Home Assistant"
+
+#: extension.js:96
+msgid "Stop Home Assistant"
+msgstr "Arrêter Home Assistant"
+
+#: extension.js:97
+msgid "Close Home Assistant"
+msgstr "Fermer Home Assistant"
+
+#: extension.js:113
+msgid "Preferences"
+msgstr "Préférences"
+
+#: prefs.js:48
+msgid "General Settings"
+msgstr "Paramètres générals"
+
+#: prefs.js:51
+msgid "Togglables"
+msgstr "Interrupteurs"
+
+#: prefs.js:56 schemas/org.gnome.shell.extensions.hass-data.gschema.xml:94
+msgid "Panel Sensors"
+msgstr "Capteurs de la barre des tâches"
+
+#: prefs.js:85
+msgid "Global options:"
+msgstr "Options générales :"
+
+#: prefs.js:103
+msgid "Temperature/Humidity options:"
+msgstr "Options de température/humidité :"
+
+#: prefs.js:132
+msgid "Panel Icon Options:"
+msgstr "Options de l'icône de la barre des tâches :"
+
+#: prefs.js:149
+#, javascript-format
+msgid "%s Icon"
+msgstr "Icône %s"
+
+#: prefs.js:157
+msgid ""
+"You will need to restart your session in order for this change to take "
+"effect."
+msgstr ""
+"Vous devrez redémarrer votre sessions pour que ce changement soit effectif."
+
+#: prefs.js:158
+msgid ""
+"On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this "
+"doesn't work (Wayland), you have to logout and re-login."
+msgstr ""
+"Sur Xorg, vous pouvez faire cela avec Alt+F2 puis taper \"r\" et Entrer. Si "
+"cela ne fonctionne pas (Wayland), vous devez vous fermer votre session puis "
+"la ré-ouvrir."
+
+#: prefs.js:282
+msgid "Togglable Entities:"
+msgstr "Entités interrupteurs :"
+
+#: prefs.js:287
+msgid "Choose Togglable Entities:"
+msgstr "Sélectionner les entités interrupteurs :"
+
+#: prefs.js:310
+msgid "Group Switches"
+msgstr "Groupes d'interrupteurs"
+
+#: prefs.js:317
+msgid "Experimental"
+msgstr "Expérimental"
+
+#: prefs.js:318
+msgid "Does not currently work."
+msgstr "Ne fonctionne pas actuellement."
+
+#: prefs.js:409
+msgid "Sensors:"
+msgstr "Capteurs :"
+
+#: prefs.js:414
+msgid "Choose Which Sensors Should Appear on the Panel:"
+msgstr "Sélectionner les capteurs qui apparaîtront dans la barre des tâches :"
+
+#: prefs.js:586
+#, javascript-format
+msgid "Do you want to have the '%s' icon in your panel?"
+msgstr "Avez-vous l'icône \"%s\" dans la barre des tâches ?"
+
+#: prefs.js:588
+#, javascript-format
+msgid "Do you want to show %s in the tray menu?"
+msgstr "Voulez-vous afficher %s dans la zone de notification ?"
+
+#: prefs.js:635
+msgid "Add"
+msgstr "Ajouter"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:16
+msgid "Panel Icon."
+msgstr "Icône de la barre des tâches."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:17
+msgid "The default icon that will be visible in the panel."
+msgstr "L'icône par défaut qui sera visible dans la barre des tâches."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:22
+msgid "Complete list of valid panel icons for the extension."
+msgstr ""
+"Liste complète des icônes de la barre des tâches valides pour l'extension."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:23
+msgid ""
+"The paths have to be relative to the directory where the 'extension.js' file "
+"is located."
+msgstr ""
+"Les chemins doivent être relatifs au dossier contenant le fichier "
+"\"extention.js\"."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:28
+msgid "Refresh Rate"
+msgstr "Fréquence de rafraîchissement"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:29
+msgid ""
+"(Currently Broken) The refresh rate for the weather statistics in seconds "
+"(works only if \"Refresh Temperature/Humidity Sensors\" is enabled)."
+msgstr ""
+"(Actuellement en panne) Le taux de rafraîchissement des statistiques météo "
+"en secondes (fonctionne uniquement si \"Rafraîchir les capteurs de "
+"température/humidité\" est activé)."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:34
+msgid "Refresh Temperature/Humidity Sensors"
+msgstr "Rafraîchir les capteurs de température/humidité"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:35
+msgid ""
+"(Currently Broken) Whether or not you want to refresh the temperature and/or "
+"humidity sensor values."
+msgstr ""
+"(Actuellement en panne) Si vous souhaitez ou non actualiser les valeurs des "
+"capteurs de température et/ou d'humidité."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:40
+msgid "Show notifications"
+msgstr "Afficher les notifications"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:41
+msgid "Show notifications when enabled/disabled."
+msgstr "Afficher les notifications lorsqu'elles sont activées/désactivées."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:46
+msgid "Show Temperature/Humidity"
+msgstr "Afficher la température/l'humidité"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:47
+msgid ""
+"Whether to show the temperature and/or humidity values (assuming you have "
+"provided the corresponding entity ids)."
+msgstr ""
+"Indique s'il faut afficher les valeurs de température et/ou d'humidité (en "
+"supposant que vous avez fourni les identifiants d'entité correspondants)."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:52
+msgid "Show Humidity"
+msgstr "Afficher l'humidité"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:53
+msgid "Whether to show humidity value or not."
+msgstr "Afficher ou non la valeur d'humidité."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:58
+msgid "Temperature ID"
+msgstr "Identifiant température"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:59
+msgid "Your Home Assistant EntityID for the temperature sensor."
+msgstr ""
+"Votre identifiant d'entité Home Assistant pour le capteur de température."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:64
+msgid "Humidity ID"
+msgstr "Identifiant humidité"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:65
+msgid "Your Home Assistant EntityID for the humidity sensor."
+msgstr "Votre identifiant d'entité Home Assistant pour le capteur d'humidité."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:70
+msgid "Access Token"
+msgstr "Jeton d'accès"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:71
+msgid ""
+"Long Live Access Token for Home Assistant (Go to Profile->Bottom-of-the-page-"
+">Long-Live-Access-Tokens and create a new one)."
+msgstr ""
+"Jeton d'accès de longue durée pour Home Assistant (Allez dans Profil-> Bas "
+"de la page-> Jetons d'accès de longue durée et créez-en un nouveau)."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:76
+msgid "URL"
+msgstr "URL"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:77
+msgid "The url where your hass instance is hosted."
+msgstr "L'url où votre instance hass est hébergée."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:82
+msgid "Complete list of entity ids for home-assistant switches."
+msgstr ""
+"Liste complète des identifiants d'entité des interrupteurs d'Home Assistant."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:83
+msgid ""
+"Full list of home assistant switches. It is meant to be filled automatically "
+"after pressing the 'Scan' button in the Preferences menu."
+msgstr ""
+"Liste complète des interrupteurs d'Home Assistant. Elle est censé être "
+"remplie automatiquement après avoir appuyé sur le bouton 'Scan' dans le menu "
+"Préférences."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:88
+msgid "Entity ids for home-assistant switches."
+msgstr "ID d'entité des interrupteurs d'Home Assistant."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:89
+msgid ""
+"Entity ids for home-assistant switches. E.g. switch.livingroom_lights_relay."
+msgstr ""
+"ID d'entité des interrupteurs d'Home Assistant. Ex : switch."
+"livingroom_lights_relay."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:95
+msgid ""
+"List of entity ids for the sensor values that you want to show in the panel ."
+msgstr ""
+"Liste des ID d'entité des capteurs dont vous souhaitez afficher la valeur "
+"dans la barre des tâches."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:100
+msgid "Entity ids for home assistant sensors."
+msgstr "ID d'entité des capteurs d'Home Assistant."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:101
+msgid ""
+"Entity ids for home-assistant sensors. E.g. sensor.livingroom_temperature ."
+msgstr ""
+"ID d'entité des capteurs d'Home Assistant.. Ex : sensor."
+"livingroom_temperature."
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:112
+msgid "Home Assistant Extension - Shortcut Key"
+msgstr "Extension Home Assistant - Raccourci clavier"
+
+#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:113
+msgid "Shortcut key on how to open the extension's menu from the tray."
+msgstr ""
+"Raccourci clavier pour ouvrir le menu de l'extension à partir de la zone de "
+"notification."
+
+#~ msgid " Icon"
+#~ msgstr " Icône"
+
+#~ msgid "' icon in your panel?"
+#~ msgstr "\" dans la barre des tâches ?"
+
+#~ msgid " in the tray menu?"
+#~ msgstr " dans la barre des tâches ?"

--- a/po/hass-gshell.pot
+++ b/po/hass-gshell.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-07 17:25+0200\n"
+"POT-Creation-Date: 2023-06-25 09:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,113 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: extension.js:75
+msgid "Toggle:"
+msgstr ""
+
+#: extension.js:93
+msgid "HASS Events"
+msgstr ""
+
+#: extension.js:95
+msgid "Start Home Assistant"
+msgstr ""
+
+#: extension.js:96
+msgid "Stop Home Assistant"
+msgstr ""
+
+#: extension.js:97
+msgid "Close Home Assistant"
+msgstr ""
+
+#: extension.js:113
+msgid "Preferences"
+msgstr ""
+
+#: prefs.js:48
+msgid "General Settings"
+msgstr ""
+
+#: prefs.js:51
+msgid "Togglables"
+msgstr ""
+
+#: prefs.js:56 schemas/org.gnome.shell.extensions.hass-data.gschema.xml:94
+msgid "Panel Sensors"
+msgstr ""
+
+#: prefs.js:85
+msgid "Global options:"
+msgstr ""
+
+#: prefs.js:103
+msgid "Temperature/Humidity options:"
+msgstr ""
+
+#: prefs.js:132
+msgid "Panel Icon Options:"
+msgstr ""
+
+#: prefs.js:149
+#, javascript-format
+msgid "%s Icon"
+msgstr ""
+
+#: prefs.js:157
+msgid ""
+"You will need to restart your session in order for this change to take "
+"effect."
+msgstr ""
+
+#: prefs.js:158
+msgid ""
+"On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this "
+"doesn't work (Wayland), you have to logout and re-login."
+msgstr ""
+
+#: prefs.js:282
+msgid "Togglable Entities:"
+msgstr ""
+
+#: prefs.js:287
+msgid "Choose Togglable Entities:"
+msgstr ""
+
+#: prefs.js:310
+msgid "Group Switches"
+msgstr ""
+
+#: prefs.js:317
+msgid "Experimental"
+msgstr ""
+
+#: prefs.js:318
+msgid "Does not currently work."
+msgstr ""
+
+#: prefs.js:409
+msgid "Sensors:"
+msgstr ""
+
+#: prefs.js:414
+msgid "Choose Which Sensors Should Appear on the Panel:"
+msgstr ""
+
+#: prefs.js:586
+#, javascript-format
+msgid "Do you want to have the '%s' icon in your panel?"
+msgstr ""
+
+#: prefs.js:588
+#, javascript-format
+msgid "Do you want to show %s in the tray menu?"
+msgstr ""
+
+#: prefs.js:635
+msgid "Add"
+msgstr ""
 
 #: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:16
 msgid "Panel Icon."
@@ -134,10 +241,6 @@ msgid ""
 "Entity ids for home-assistant switches. E.g. switch.livingroom_lights_relay."
 msgstr ""
 
-#: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:94 prefs.js:56
-msgid "Panel Sensors"
-msgstr ""
-
 #: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:95
 msgid ""
 "List of entity ids for the sensor values that you want to show in the panel ."
@@ -158,112 +261,4 @@ msgstr ""
 
 #: schemas/org.gnome.shell.extensions.hass-data.gschema.xml:113
 msgid "Shortcut key on how to open the extension's menu from the tray."
-msgstr ""
-
-#: extension.js:77
-msgid "Toggle:"
-msgstr ""
-
-#: extension.js:95
-msgid "HASS Events"
-msgstr ""
-
-#: extension.js:97
-msgid "Start Home Assistant"
-msgstr ""
-
-#: extension.js:98
-msgid "Stop Home Assistant"
-msgstr ""
-
-#: extension.js:99
-msgid "Close Home Assistant"
-msgstr ""
-
-#: extension.js:115
-msgid "Preferences"
-msgstr ""
-
-#: prefs.js:48
-msgid "General Settings"
-msgstr ""
-
-#: prefs.js:51
-msgid "Togglables"
-msgstr ""
-
-#: prefs.js:82
-msgid "Global options:"
-msgstr ""
-
-#: prefs.js:100
-msgid "Temperature/Humidity options:"
-msgstr ""
-
-#: prefs.js:129
-msgid "Panel Icon Options:"
-msgstr ""
-
-#: prefs.js:146
-msgid " Icon"
-msgstr ""
-
-#: prefs.js:154
-msgid ""
-"You will need to restart your session in order for this change to take "
-"effect."
-msgstr ""
-
-#: prefs.js:155
-msgid ""
-"On Xorg, you can do that by Alt+F2 and then pressing 'r' and Enter. If this "
-"doesn't work (Wayland), you have to logout and re-login."
-msgstr ""
-
-#: prefs.js:279
-msgid "Togglable Entities:"
-msgstr ""
-
-#: prefs.js:284
-msgid "Choose Togglable Entities:"
-msgstr ""
-
-#: prefs.js:307
-msgid "Group Switches"
-msgstr ""
-
-#: prefs.js:314
-msgid "Experimental"
-msgstr ""
-
-#: prefs.js:315
-msgid "Does not currently work."
-msgstr ""
-
-#: prefs.js:406
-msgid "Sensors:"
-msgstr ""
-
-#: prefs.js:411
-msgid "Choose Which Sensors Should Appear on the Panel:"
-msgstr ""
-
-#: prefs.js:583
-msgid "Do you want to have the '"
-msgstr ""
-
-#: prefs.js:583
-msgid "' icon in your panel?"
-msgstr ""
-
-#: prefs.js:585
-msgid "Do you want to show "
-msgstr ""
-
-#: prefs.js:585
-msgid " in the tray menu?"
-msgstr ""
-
-#: prefs.js:632
-msgid "Add"
 msgstr ""

--- a/prefs.js
+++ b/prefs.js
@@ -562,8 +562,8 @@ function _makeSwitch(name, schema) {
     let gtkSwitch = _newGtkSwitch();
     return [
         _optionsItem(
-            key.get_summary(),
-            key.get_description(),
+            _(key.get_summary()),
+            _(key.get_description()),
             gtkSwitch,
             null
         ),

--- a/prefs.js
+++ b/prefs.js
@@ -146,7 +146,7 @@ function _buildGeneralSettings() {
                       .split("-")
                       .map(word => word.charAt(0).toUpperCase() + word.slice(1))
                       .join(" ");
-        let [iconItem, panelIconCheckBox] = _makeCheckBox(label + _(" Icon"), checked, superGroup);
+        let [iconItem, panelIconCheckBox] = _makeCheckBox(_("%s Icon").format(label), checked, superGroup);
         optionsList.push(iconItem);
         iconCheckBoxes.push({
             icon: ic,
@@ -583,9 +583,9 @@ function _makeCheckBox(name, checked, buttonGroup) {
     let gtkCheckBox = _newGtkCheckBox(checked, buttonGroup);
     let desc;
     if (buttonGroup !== undefined) {
-        desc = _("Do you want to have the '") + name + _("' icon in your panel?");
+        desc = _("Do you want to have the '%s' icon in your panel?").format(name);
     } else {
-        desc = _("Do you want to show ") + name + _(" in the tray menu?");
+        desc = _("Do you want to show %s in the tray menu?").format(name)
     }
     return [
         _optionsItem(


### PR DESCRIPTION
Hello,

Thanks for this great extension! I worked to add french translation on it and I fixed/improved some related things:

- the label and the description of switch options in preferences was not translated
- I switch to use string formatting for composed translatable messages to allow to correctly translate messages whatever the order of the words in the target language (and I managed these changes in DE and ES po files).

__Note:__ I noticed a strange message in schema _"Full list of home assistant switches. It is meant to be filled automatically after pressing the 'Scan' button in the Preferences menu."_ I can't found this "Scan" button (nor the label of this button in translatable messages) and I thought it might be a button that was removed following the evolution of the extension. Is that the case?