### PR TITLE
Store & retreive the API Long-Live token asynchronously

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -296,17 +296,20 @@ class HassPrefs {
           Utils._log('Access token changed: "%s"', [row.get_text()]);
           let new_value = row.get_text();
           if (!new_value) return;
-          Secret.password_store_sync(
+          Secret.password_store(
               Utils.getTokenSchema(),
               {"token_string": "user_token"},
               Secret.COLLECTION_DEFAULT,
               "long_live_access_token",
               row.get_text(),
-              null
+              null,
+              (source, result) => {
+                  Secret.password_store_finish(result);
+                  // Always force reload entities cache in case of HASS Token change and invalidate it in case
+                  // of error
+                  Utils.getEntities(null, () => Utils.invalidateEntitiesCache(), true);
+              }
           );
-          // Always force reload entities cache in case of HASS Token change and invalidate it in case
-          // of error
-          Utils.getEntities(null, () => Utils.invalidateEntitiesCache(), true);
         });
 
         return row;


### PR DESCRIPTION
I forget these synchronous tasks on working on #62 . Furthermore, on one of my laptops, I occasionally have strange behavior when I opening a session: the `Secret.password_lookup_sync()` return `null` during variable time. I'm not sure why this problem occurred, but I notice that if I manually start [seahorse](https://wiki.gnome.org/Apps/Seahorse), it seem unlock the access to the token and I don't I have no more problems then. I hope this change could help.