### PR TITLE
Work around bug in gnome-keyring preventing keyring unlocking

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -35,8 +35,14 @@ export function disable() {
 
 export function getTokenSchema() {
     if (!TOKEN_SCHEMA) {
-        TOKEN_SCHEMA = Secret.Schema.new("org.gnome.hass-data.Password",
-            Secret.SchemaFlags.NONE,
+        TOKEN_SCHEMA = Secret.Schema.new(
+            "org.gnome.hass-data.Password",
+            /** DONT_MATCH_NAME is used as a workaround for a bug in gnome-keyring
+             *  which prevents cold keyrings from being searched (and hence does not prompt for unlocking)
+             *  see https://gitlab.gnome.org/GNOME/gnome-keyring/-/issues/89 and
+             *  https://gitlab.gnome.org/GNOME/libsecret/-/issues/7 for more information
+             */
+            Secret.SchemaFlags.DONT_MATCH_NAME,
             {
                 "token_string": Secret.SchemaAttributeType.STRING,
             }


### PR DESCRIPTION
I finally found the cause of [my problem to access API long-live token on startup](https://github.com/geoph9/hass-gshell-extension/pull/66#issuecomment-1636717593) (and when keyring is cold): this is due of an old [_gnome-keyring_ bug](https://gitlab.gnome.org/GNOME/gnome-keyring/-/issues/89) which forced many projects to find a work-around. Some on them implemented a work around by firstly store an useless password to force unlocking the keyrings before trying to retrieve their secrets (eg. [chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=660005)), but the cleanest solution seemed to me to be the one adopted by some other projects of the GNOME foundation (like [calls](https://gitlab.gnome.org/GNOME/calls/-/merge_requests/384/diffs?commit_id=9d9e989be49cf708f5e4f896c2ba3395eac07207)), which consists of using the flag `SECRET_SCHEMA_DONT_MATCH_NAME` when creating the secret schema (as [proposed by in a related issue](https://gitlab.gnome.org/GNOME/libsecret/-/issues/7) of the _libsecret_ project).

**Note:** a [work-around](https://gitlab.gnome.org/GNOME/libsecret/-/merge_requests/105) (or solution) has obviously been implemented in the version `0.21.0` of the _libsecret_ project but I am still impacted on my Debian stable work-stations since it still uses version `0.20.5` _libsecret_ version.

**PS:** Would it be possible to release a new version including this fix for versions < GNOME 45?