### PR TITLE
Gnome 47: bump version number in metadata; no major updates required

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,9 +5,9 @@
   "name": "Home Assistant Extension",
   "settings-schema": "org.gnome.shell.extensions.hass-data",
   "shell-version": [
-    "45", "46"
+    "45", "46", "47"
   ],
   "url": "https://github.com/geoph9/hass-gshell-extension",
   "uuid": "hass-gshell@geoph9-on-github",
-  "version": 24.0
+  "version": 25.0
 }


### PR DESCRIPTION
Seems to work just fine under Gnome 47.