### PR TITLE
Add Gnome 50 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "gettext-domain": "hass-gshell",
   "name": "Home Assistant Extension",
   "settings-schema": "org.gnome.shell.extensions.hass-data",
-  "shell-version": ["45", "46", "47", "48", "49"],
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "url": "https://github.com/geoph9/hass-gshell-extension",
   "uuid": "hass-gshell@geoph9-on-github",
   "version": 26.1


### PR DESCRIPTION
Tested on Fedora 44 with Gnome 50. Works fine. Closes #94.